### PR TITLE
add missing param and fix an error with terraform source

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.2.3
+VERSION=v0.2.4
 NAME=cloud-infrastructure-sdk
 
 

--- a/pkg/scaffold/ansibleterraform/tflive_aws_terragrunt_hcl.go
+++ b/pkg/scaffold/ansibleterraform/tflive_aws_terragrunt_hcl.go
@@ -31,8 +31,7 @@ const terragruntAwsHclTmpl = `include {
 }
 
 terraform {
-  #source = "../../../../modules/{{.AppName}}/aws"
-  source = "github.com/foo/confluent"
+  source = "../../../../modules/{{.AppName}}/aws"
 }
 
 locals {
@@ -48,6 +47,7 @@ inputs = {
   dns_zone_id                     = local.vars.dns_zone_id
   vpc_id                          = local.vars.{{.AppName}}.vpc_id
   vault_addr                      = local.vars.vault_addr
+  vault_ssh_ca_path               = local.vars.vault_ssh_ca_path
 
   nodes_count                     = local.vars.{{.AppName}}.nodes_count
   nodes_instance_type             = local.vars.{{.AppName}}.nodes_instance_type


### PR DESCRIPTION
Description:
Resolved the following:
The terragrunt.hcl source value in the terragrunt aws hcl template reverted to a regressed state.
Identified a missing param in the terragrunt aws hcl template needed for vault ssh cert.

