### PR TITLE
add ssh user configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.2.9
+VERSION=v0.2.10
 NAME=cloud-infrastructure-sdk
 
 

--- a/pkg/cli/ansibleterraform.go
+++ b/pkg/cli/ansibleterraform.go
@@ -20,6 +20,7 @@ func AnsibleTerraformCmd() *cobra.Command {
 	ansibleTerraformCmd.PersistentFlags().StringVar(&vaultAddr, "vault-addr", "https://vault-demo.ews.works", "The hashicorp vault server")
 	ansibleTerraformCmd.PersistentFlags().StringVar(&vaultSSHCa, "vault-ssh-ca", "", "The hashicorp vault ssh ca secret engine path")
 	ansibleTerraformCmd.PersistentFlags().StringVar(&vaultSSHRole, "vault-ssh-role", "", "The hashicorp vault ssh role name")
+	ansibleTerraformCmd.PersistentFlags().StringVar(&sshUser, "ssh-user", "$USER", "The ssh username")
 	ansibleTerraformCmd.PersistentFlags().StringVar(&awsRegion, "aws-region", "us-west-2", "The aws region when the infrastructure provider is type aws")
 	ansibleTerraformCmd.PersistentFlags().StringVar(&s3BucketName, "s3-bucket-name", "ews-works", "The remote state s3 bucket name")
 	ansibleTerraformCmd.PersistentFlags().StringVar(&s3BucketRegion, "s3-bucket-region", "us-west-2", "The remote state s3 bucket region")
@@ -33,7 +34,7 @@ func InitAnsibleTerraformProjectCmd() *cobra.Command {
 		Use:   "init",
 		Short: "creates a new ansible-terraform project",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			err := sdkcmd.InitAnsibleTerraformScaffold(configFile, terragruntVarsFile, cliName, Version, projectName, appName, infraProvider, dcName, envNames, vaultAddr, vaultSSHCa, vaultSSHRole, awsRegion, s3BucketName, s3BucketRegion)
+			err := sdkcmd.InitAnsibleTerraformScaffold(configFile, terragruntVarsFile, cliName, Version, projectName, appName, infraProvider, dcName, envNames, vaultAddr, vaultSSHCa, vaultSSHRole, sshUser, awsRegion, s3BucketName, s3BucketRegion)
 			return err
 		},
 	}

--- a/pkg/cli/cmd.go
+++ b/pkg/cli/cmd.go
@@ -19,6 +19,7 @@ var (
 	vaultAddr          string
 	vaultSSHCa         string
 	vaultSSHRole       string
+	sshUser            string
 	awsRegion          string
 	terragruntVarsFile string
 )

--- a/pkg/cmd/ansibleterraform.go
+++ b/pkg/cmd/ansibleterraform.go
@@ -12,7 +12,7 @@ import (
 )
 
 // InitAnsibleTerraformScaffold creates or updates the ansible/terraform project
-func InitAnsibleTerraformScaffold(configFilePath, terragruntVarsFilePath, cliName, cliVersion, projectName, appName, infraProvider, dcName string, envNames []string, vaultAddr, vaultSSHCa, vaultSSHRole, awsRegion, s3BucketName, s3BucketRegion string) error {
+func InitAnsibleTerraformScaffold(configFilePath, terragruntVarsFilePath, cliName, cliVersion, projectName, appName, infraProvider, dcName string, envNames []string, vaultAddr, vaultSSHCa, vaultSSHRole, sshUser, awsRegion, s3BucketName, s3BucketRegion string) error {
 	userCfg := config.NewConfig()
 	userCfg.ReadConfigFile(configFilePath)
 
@@ -110,7 +110,16 @@ func InitAnsibleTerraformScaffold(configFilePath, terragruntVarsFilePath, cliNam
 		// render infrastructure provider specific templates
 		if infraProvider == "aws" {
 			err = s.Execute(cfg,
-				&ansibleterraform.EnvAwsSh{EnvName: envName, AppName: appName, DCName: dcName, AWSRegion: awsRegion, VaultAddr: vaultAddr, VaultSSHCa: vaultSSHCa, VaultSSHRole: vaultSSHRole},
+				&ansibleterraform.EnvAwsSh{
+					EnvName:      envName,
+					AppName:      appName,
+					DCName:       dcName,
+					AWSRegion:    awsRegion,
+					VaultAddr:    vaultAddr,
+					VaultSSHCa:   vaultSSHCa,
+					VaultSSHRole: vaultSSHRole,
+					SSHUser:      sshUser,
+				},
 				&ansibleterraform.TerragruntAwsHcl{EnvName: envName, AppName: appName, DCName: dcName},
 				&ansibleterraform.TerragruntAwsVars{
 					EnvName:        envName,

--- a/pkg/scaffold/ansibleterraform/env_aws_sh.go
+++ b/pkg/scaffold/ansibleterraform/env_aws_sh.go
@@ -22,6 +22,7 @@ type EnvAwsSh struct {
 	VaultAddr           string
 	VaultSSHCa          string
 	VaultSSHRole        string
+	SSHUser             string
 	TfLiveBaseDir       string
 	AnsibleInventoryDir string
 }
@@ -46,12 +47,13 @@ export AWS_CA_BUNDLE=/etc/ssl/certs/ca-bundle.crt
 export AWS_REGION={{.AWSRegion}}
 export ASSUME_ROLE_ARN=${ASSUME_ROLE_ARN} # set by user
 export VAULT_ADDR={{.VaultAddr}}
-export VAULT_SSH_CERT_PRINCIPAL=${VAULT_SSH_CERT_PRINCIPAL} # set by user
-export VAULT_SSH_CLIENT_SIGNER_PATH={{.VaultSSHCa}}/sign/{{.VaultSSHRole}}# set by user
+export VAULT_SSH_CERT_PRINCIPAL=${VAULT_SSH_CERT_PRINCIPAL:-{{.SSHUser}}} # set by user
+export VAULT_SSH_CLIENT_SIGNER_PATH={{.VaultSSHCa}}/sign/{{.VaultSSHRole}} # set by user
 
 
-## set environment for the automation user
-export AUTOMATION_USER_VAULT_PATHS=() # user defined list
+## set environment for the automation user.
+## the AUTOMATION_USER_VAULT_PATHS need to be templated
+export AUTOMATION_USER_VAULT_PATHS=( 
   provision/data/trusted-orchestrator/corp
   provision/data/trusted-orchestrator/aws-iam-svc-terraform-dev
 )

--- a/pkg/scaffold/scripts/vault_helpers_sh.go
+++ b/pkg/scaffold/scripts/vault_helpers_sh.go
@@ -28,7 +28,7 @@ const VaultHelpersShTmpl = `#!/bin/bash
 #### edits to this file will be overwritten the next time {{.CliName}} runs on this project
 
 # vault-helpers defaults
-VAULT_SSH_CERT_PRINCIPAL=${VAULT_SSH_CERT_PRINCIPAL:-provisioner}
+VAULT_SSH_CERT_PRINCIPAL=${VAULT_SSH_CERT_PRINCIPAL}
 
 # source the project config when it exists
 [ -e "./scripts/config.sh" ] && source ./scripts/config.sh


### PR DESCRIPTION
The ssh user needs to be configured on project environment creation so that a project environment can be converged upon creation.

This PR allows the user to configure vault ssh ca client and the ssh username.